### PR TITLE
Infer function schema from reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install openai-function-calling
 
 ## Usage
 
-### Automatically Infer the Function Definition (Beta)
+### Auto-Infer the Function Definition (Beta)
 
 Automatically infer your function name, description, and parameters given a reference to the function. A `Function` instance is returned which can be converted to JSON schema with `.to_json_schema()` and then passed to the OpenAI chat completion API:
 

--- a/README.md
+++ b/README.md
@@ -16,30 +16,59 @@ pip install openai-function-calling
 
 ## Usage
 
+### Automatically Infer the Function Definition (Beta)
+
+Automatically infer your function name, description, and parameters given a reference to the function. A `Function` instance is returned which can be converted to JSON schema with `.to_json_schema()` and then passed to the OpenAI chat completion API:
+
+```python
+def get_current_weather(location: str, unit: str) -> str:
+    """Get the current weather and return a summary."""
+    return f"It is currently sunny in {location} and 75 degrees {unit}."
+
+get_current_weather_json_schema = Function.from_function(get_current_weather).to_json_schema()
+
+# Get the function to call from ChatGPT (you would normally have more than one).
+response = openai.ChatCompletion.create(
+    model="gpt-3.5-turbo-0613",
+    messages=[
+        {
+            "role": "user",
+            "content": "What will the weather be like in Boston, MA today?",
+        }
+    ],
+    functions=[get_current_weather_json_schema],
+)
+```
+
+### Define Functions with Objects
+
+Define your function definitions using typed classes `Function` and `Parameter` which automatically convert to JSON schema with `.to_json_schema` methods. See an example below:
+
 ```python
 from openai_function_calling import Function, FunctionDict, Parameter, JsonSchemaType
 
-def get_current_weather(location: str, unit: str) -> str:
-  # Do some stuff here...
 
-# Define the function parameters.
-location_parameter = Parameter(
-    name="location",
-    type=JsonSchemaType.STRING,
-    description="The city and state, e.g. San Francisco, CA"
-)
-unit_parameter = Parameter(
-    name="unit",
-    type=JsonSchemaType.STRING,
-    description="The temperature unit to use.",
-    enum=["celsius", "fahrenheit"]
-)
+def get_current_weather(location: str, unit: str) -> str:
+    """Do some stuff in here."""
+
 
 # Define the function.
 get_current_weather_function = Function(
     "get_current_weather",
     "Get the current weather",
-    [location_parameter, unit_parameter],
+    [
+        Parameter(
+            name="location",
+            type=JsonSchemaType.STRING,
+            description="The city and state, e.g. San Francisco, CA",
+        ),
+        Parameter(
+            name="unit",
+            type=JsonSchemaType.STRING,
+            description="The temperature unit to use.",
+            enum=["celsius", "fahrenheit"],
+        ),
+    ],
 )
 
 # Convert to a JSON schema dict to send to OpenAI.
@@ -49,7 +78,10 @@ get_current_weather_function_dict = get_current_weather_function.to_json_schema(
 response = openai.ChatCompletion.create(
     model="gpt-3.5-turbo-0613",
     messages=[
-      {"role": "user", "content": "What will the weather be like in Boston, MA tomorrow?"}
+        {
+            "role": "user",
+            "content": "What will the weather be like in Boston, MA tomorrow?",
+        }
     ],
     functions=[get_current_weather_function_dict],
 )

--- a/examples/weather_functions_infer.py
+++ b/examples/weather_functions_infer.py
@@ -9,7 +9,8 @@ from collections.abc import Callable
 from typing import Any
 
 import openai
-from openai_function_calling import Function
+
+from openai_function_calling import FunctionInferer
 
 
 # Define our functions.
@@ -23,12 +24,12 @@ def get_tomorrows_weather(location: str, unit: str) -> str:
     return f"It will be rainy tomorrow in {location} and around 65 degrees {unit}."
 
 
-get_current_weather_schema = Function.from_function(
-    get_current_weather
+get_current_weather_schema = FunctionInferer.infer_from_function_reference(
+    get_current_weather,
 ).to_json_schema()
 
-get_tomorrows_weather_schema = Function.from_function(
-    get_tomorrows_weather
+get_tomorrows_weather_schema = FunctionInferer.infer_from_function_reference(
+    get_tomorrows_weather,
 ).to_json_schema()
 
 

--- a/examples/weather_functions_infer.py
+++ b/examples/weather_functions_infer.py
@@ -1,0 +1,65 @@
+"""Weather Example.
+
+Uses the function calling wrappers to decide between two functions
+and extract entities to pass into the chosen function as arguments.
+"""
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import openai
+from openai_function_calling import Function
+
+
+# Define our functions.
+def get_current_weather(location: str, unit: str) -> str:
+    """Get the current weather and return a summary."""
+    return f"It is currently sunny in {location} and 75 degrees {unit}."
+
+
+def get_tomorrows_weather(location: str, unit: str) -> str:
+    """Get tomorrow's weather and return a summary."""
+    return f"It will be rainy tomorrow in {location} and around 65 degrees {unit}."
+
+
+get_current_weather_schema = Function.from_function(
+    get_current_weather
+).to_json_schema()
+
+get_tomorrows_weather_schema = Function.from_function(
+    get_tomorrows_weather
+).to_json_schema()
+
+
+# Send the query and our function context to OpenAI.
+response: Any = openai.ChatCompletion.create(
+    model="gpt-3.5-turbo-0613",
+    messages=[
+        {
+            "role": "user",
+            "content": "What will the weather be tomorrow in Boston MA in celsius?",
+        },
+    ],
+    functions=[get_current_weather_schema, get_tomorrows_weather_schema],
+    function_call="auto",  # Auto is the default.
+)
+
+response_message = response["choices"][0]["message"]
+
+# Check if GPT wants to call a function.
+if response_message.get("function_call"):
+    # Call the function.
+    available_functions: dict[str, Callable] = {
+        "get_current_weather": get_current_weather,
+        "get_tomorrows_weather": get_tomorrows_weather,
+    }
+
+    function_name = response_message["function_call"]["name"]
+    function_args = json.loads(response_message["function_call"]["arguments"])
+    function_to_call: Callable = available_functions[function_name]
+    function_response: Any = function_to_call(**function_args)
+
+    print(f"Called {function_name} with response: '{function_response!s}'.")
+else:
+    print("GPT does not want to called a function for the given query.")

--- a/openai_function_calling/__init__.py
+++ b/openai_function_calling/__init__.py
@@ -1,6 +1,7 @@
 """OpenAI Function Calling Package."""
 
 from openai_function_calling.function import Function, FunctionDict, ParametersDict
+from openai_function_calling.function_inferer import FunctionInferer
 from openai_function_calling.json_schema_type import JsonSchemaType
 from openai_function_calling.parameter import Parameter, ParameterDict
 
@@ -11,4 +12,5 @@ __all__: list[str] = [
     "Parameter",
     "ParameterDict",
     "JsonSchemaType",
+    "FunctionInferer",
 ]

--- a/openai_function_calling/function.py
+++ b/openai_function_calling/function.py
@@ -1,11 +1,21 @@
 """Define the Function class and related objects."""
 
-from typing import TypedDict
 
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING, Any, TypedDict
+from warnings import warn
+
+from docstring_parser import Docstring, parser
 from typing_extensions import NotRequired, deprecated
 
+from openai_function_calling.helper_functions import python_type_to_json_schema_type
 from openai_function_calling.json_schema_type import JsonSchemaType
 from openai_function_calling.parameter import Parameter, ParameterDict
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class ParametersDict(TypedDict):
@@ -45,7 +55,7 @@ class Function:
         """
         self.name: str = name
         self.description: str = description
-        self.parameters: list[Parameter] | None = parameters
+        self.parameters: list[Parameter] = parameters or []
         self.required_parameters: list[str] | None = required_parameters
 
         self.validate()
@@ -109,3 +119,97 @@ class Function:
         output_dict["parameters"]["required"] = self.required_parameters
 
         return output_dict
+
+    @staticmethod
+    def from_function(function_reference: Callable) -> Function:
+        """Infer a function definition given a function reference.
+
+        The type hints and docstring are used to infer the type and descriptions.
+
+        Args:
+            function_reference: The function reference to generate a definition for.
+
+        Return:
+            An instance of Function with inferred values.
+        """
+        function_description: str = ""
+        parameters_by_name: dict[str, Parameter] = {}
+
+        if hasattr(function_reference, "__doc__") and function_reference.__doc__:
+            docstring: str = function_reference.__doc__
+            parsed_docstring: Docstring = parser.parse(docstring)
+
+            function_description = (
+                parsed_docstring.short_description
+                or parsed_docstring.long_description
+                or ""
+            )
+
+            for param in parsed_docstring.params:
+                parameters_by_name[param.arg_name] = Parameter(
+                    name=param.arg_name,
+                    type=python_type_to_json_schema_type(param.type_name),
+                    description=param.description,
+                )
+        else:
+            warn("Unable to find a docstring on the referenced function.", stacklevel=1)
+
+        if hasattr(function_reference, "__annotations__"):
+            annotations: dict[str, Any] = function_reference.__annotations__
+
+            # If arguments are defined in the docstring and they don't match the count in the function defintion
+            # throw an error
+            if (
+                len(parameters_by_name) > 0
+                and len(annotations) != 1
+                and len(parameters_by_name) != len(annotations) - 1
+            ):
+                raise ValueError(
+                    "Mismatch between argument count in function definition "
+                    "and function docstring.",
+                )
+
+            for key in annotations:
+                if key == "return":
+                    continue
+
+                parameter_type: str = python_type_to_json_schema_type(
+                    annotations[key].__name__,
+                )
+
+                if key not in parameters_by_name:
+                    parameters_by_name[key] = Parameter(name=key, type=parameter_type)
+                elif (
+                    key in parameters_by_name
+                    and parameters_by_name[key].type == JsonSchemaType.NULL
+                ):
+                    parameters_by_name[key].type = parameter_type
+
+        inspected_parameters = inspect.signature(function_reference).parameters
+
+        if len(parameters_by_name) > 0 and len(parameters_by_name) != len(
+            inspected_parameters,
+        ):
+            raise RuntimeError(
+                "The count of arguments found from the docstring and annotations "
+                "does not match the actual function arguments.",
+            )
+
+        for name, parameter in inspected_parameters.items():
+            parameter_type = python_type_to_json_schema_type(parameter.kind.name)
+
+            if name not in parameters_by_name:
+                parameters_by_name[name] = Parameter(name=name, type=parameter_type)
+            elif (
+                name in parameters_by_name
+                and parameters_by_name[name].type == JsonSchemaType.NULL
+            ):
+                parameters_by_name[name].type = parameter_type
+
+        parameters_list = list(parameters_by_name.values())
+
+        return Function(
+            name=function_reference.__name__,
+            description=function_description,
+            parameters=parameters_list,
+        )

--- a/openai_function_calling/function.py
+++ b/openai_function_calling/function.py
@@ -108,7 +108,7 @@ class Function:
             "name": self.name,
             "description": self.description,
             "parameters": {
-                "type": JsonSchemaType.OBJECT,
+                "type": JsonSchemaType.OBJECT.value,
                 "properties": parameters_dict,
             },
         }

--- a/openai_function_calling/function_inferer.py
+++ b/openai_function_calling/function_inferer.py
@@ -1,0 +1,39 @@
+from typing import Callable
+from warnings import warn
+
+from docstring_parser import Docstring, parser
+
+from openai_function_calling.function import Function
+from openai_function_calling.helper_functions import python_type_to_json_schema_type
+from openai_function_calling.parameter import Parameter
+
+
+class FunctionInferer:
+    @staticmethod
+    def infer_from_docstring(function_reference: Callable) -> Function:
+        function_definition = Function(
+            name=function_reference.__name__, description="", parameters=[]
+        )
+        parameters_by_name: dict[str, Parameter] = {}
+
+        if not hasattr(function_reference, "__doc__") or not function_reference.__doc__:
+            warn("Unable to find a docstring on the referenced function.", stacklevel=1)
+            return function_definition
+
+        docstring: str = function_reference.__doc__
+        parsed_docstring: Docstring = parser.parse(docstring)
+
+        function_definition.description = (
+            parsed_docstring.short_description
+            or parsed_docstring.long_description
+            or ""
+        )
+
+        for param in parsed_docstring.params:
+            parameters_by_name[param.arg_name] = Parameter(
+                name=param.arg_name,
+                type=python_type_to_json_schema_type(param.type_name),
+                description=param.description,
+            )
+
+        return function_definition

--- a/openai_function_calling/helper_functions.py
+++ b/openai_function_calling/helper_functions.py
@@ -1,0 +1,38 @@
+"""Helper functions used throughout the package."""
+
+from openai_function_calling.json_schema_type import JsonSchemaType
+
+
+def python_type_to_json_schema_type(python_type: str | None) -> str:
+    """Convert a python type string to a value JSON schema type.
+
+    Args:
+        python_type: A string representation of a python type.
+
+    Returns:
+        A JSON schema type value.
+    """
+    json_schema_type: str = JsonSchemaType.NULL.value
+
+    if python_type in {f.value for f in JsonSchemaType}:
+        json_schema_type = python_type
+
+    if python_type == "int":
+        json_schema_type = JsonSchemaType.INTEGER.value
+
+    if python_type in {"float", "complex"}:
+        json_schema_type = JsonSchemaType.NUMBER.value
+
+    if python_type == "str":
+        json_schema_type = JsonSchemaType.STRING.value
+
+    if python_type == "bool":
+        json_schema_type = JsonSchemaType.BOOLEAN.value
+
+    if python_type == "dict":
+        json_schema_type = JsonSchemaType.OBJECT.value
+
+    if python_type == "list":
+        json_schema_type = JsonSchemaType.ARRAY.value
+
+    return json_schema_type

--- a/openai_function_calling/parameter.py
+++ b/openai_function_calling/parameter.py
@@ -1,10 +1,13 @@
 """Define the Parameter class and related objects."""
 
-from typing import Any, TypedDict
+from __future__ import annotations
 
-from typing_extensions import NotRequired
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from openai_function_calling.json_schema_type import JsonSchemaType
+
+if TYPE_CHECKING:
+    from typing_extensions import NotRequired
 
 
 class ItemsDict(TypedDict):
@@ -100,3 +103,49 @@ class Parameter:
             output_dict["items"] = {"type": self.array_item_type}
 
         return output_dict
+
+    def merge(self, other_parameter: Parameter) -> None:
+        """Merge another parameter into the current instance.
+
+        Will not replace values that already exist.
+
+        Args:
+            other_parameter: The other parameter instance to merge into the current.
+        """
+        if not isinstance(other_parameter, Parameter):
+            raise TypeError("Cannot merge non-parameter type into parameter.")
+
+        if self.name is None:
+            self.name = other_parameter.name
+
+        if self.type is None or self.type == JsonSchemaType.NULL:
+            self.type = other_parameter.type
+
+        if self.description is None:
+            self.description = other_parameter.description
+
+        if self.enum is None:
+            self.enum = other_parameter.enum
+
+        if self.array_item_type is None or self.array_item_type == JsonSchemaType.NULL:
+            self.array_item_type = other_parameter.array_item_type
+
+    def __eq__(self, other: Any) -> bool:
+        """Test if an object is equivalent to the parameter.
+
+        Args:
+            other: The other value to compare against.
+
+        Returns:
+            If the other object is equal to the current instance.
+        """
+        if not isinstance(other, Parameter):
+            return False
+
+        return (
+            self.name == other.name
+            and self.type == other.type
+            and self.description == other.description
+            and self.enum == other.enum
+            and self.array_item_type == other.array_item_type
+        )

--- a/poetry.lock
+++ b/poetry.lock
@@ -426,15 +426,27 @@ files = [
 toml = ["tomli"]
 
 [[package]]
+name = "docstring-parser"
+version = "0.15"
+description = "Parse Python docstrings in reST, Google and Numpydoc format"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4.0"
+files = [
+    {file = "docstring_parser-0.15-py3-none-any.whl", hash = "sha256:d1679b86250d269d06a99670924d6bce45adc00b08069dae8c47d98e89b667a9"},
+    {file = "docstring_parser-0.15.tar.gz", hash = "sha256:48ddc093e8b1865899956fcc03b03e66bb7240c310fac5af81814580c55bf682"},
+]
+
+[[package]]
 name = "exceptiongroup"
-version = "1.1.1"
+version = "1.1.2"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
-    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
+    {file = "exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
+    {file = "exceptiongroup-1.1.2.tar.gz", hash = "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5"},
 ]
 
 [package.extras]
@@ -785,29 +797,29 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "ruff"
-version = "0.0.275"
+version = "0.0.276"
 description = "An extremely fast Python linter, written in Rust."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.0.275-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:5e6554a072e7ce81eb6f0bec1cebd3dcb0e358652c0f4900d7d630d61691e914"},
-    {file = "ruff-0.0.275-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:1cc599022fe5ffb143a965b8d659eb64161ab8ab4433d208777eab018a1aab67"},
-    {file = "ruff-0.0.275-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5206fc1cd8c1c1deadd2e6360c0dbcd690f1c845da588ca9d32e4a764a402c60"},
-    {file = "ruff-0.0.275-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c4e6468da26f77b90cae35319d310999f471a8c352998e9b39937a23750149e"},
-    {file = "ruff-0.0.275-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0dbdea02942131dbc15dd45f431d152224f15e1dd1859fcd0c0487b658f60f1a"},
-    {file = "ruff-0.0.275-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:22efd9f41af27ef8fb9779462c46c35c89134d33e326c889971e10b2eaf50c63"},
-    {file = "ruff-0.0.275-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c09662112cfa22d7467a19252a546291fd0eae4f423e52b75a7a2000a1894db"},
-    {file = "ruff-0.0.275-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80043726662144876a381efaab88841c88e8df8baa69559f96b22d4fa216bef1"},
-    {file = "ruff-0.0.275-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5859ee543b01b7eb67835dfd505faa8bb7cc1550f0295c92c1401b45b42be399"},
-    {file = "ruff-0.0.275-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c8ace4d40a57b5ea3c16555f25a6b16bc5d8b2779ae1912ce2633543d4e9b1da"},
-    {file = "ruff-0.0.275-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8347fc16aa185aae275906c4ac5b770e00c896b6a0acd5ba521f158801911998"},
-    {file = "ruff-0.0.275-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ec43658c64bfda44fd84bbea9da8c7a3b34f65448192d1c4dd63e9f4e7abfdd4"},
-    {file = "ruff-0.0.275-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:508b13f7ca37274cceaba4fb3ea5da6ca192356323d92acf39462337c33ad14e"},
-    {file = "ruff-0.0.275-py3-none-win32.whl", hash = "sha256:6afb1c4422f24f361e877937e2a44b3f8176774a476f5e33845ebfe887dd5ec2"},
-    {file = "ruff-0.0.275-py3-none-win_amd64.whl", hash = "sha256:d9b264d78621bf7b698b6755d4913ab52c19bd28bee1a16001f954d64c1a1220"},
-    {file = "ruff-0.0.275-py3-none-win_arm64.whl", hash = "sha256:a19ce3bea71023eee5f0f089dde4a4272d088d5ac0b675867e074983238ccc65"},
-    {file = "ruff-0.0.275.tar.gz", hash = "sha256:a63a0b645da699ae5c758fce19188e901b3033ec54d862d93fcd042addf7f38d"},
+    {file = "ruff-0.0.276-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:c150912b8ebde843c10b33db90705d4fee48db6f05441e5d143be9f4c2f35df5"},
+    {file = "ruff-0.0.276-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:5e9cd7238d34f24d7ccfadcce4dc6807b8c5a390f547dd7236d06488d9d6f40f"},
+    {file = "ruff-0.0.276-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc7dc557cc3fa2a03a88e99425ceee91429cc7432e5a41087850c1629294faed"},
+    {file = "ruff-0.0.276-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:13e5983836ae383c04de213954da731f14ea884aaf74467abc47e1d79d8cf1b7"},
+    {file = "ruff-0.0.276-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ac65df96be3e2f4b10bc97bbb624152281611b06ef1068d5bb064b7ad35d800"},
+    {file = "ruff-0.0.276-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d070a64de4affd17e006d6986ef25601dbbc6b373844ece5396c33900f8b8563"},
+    {file = "ruff-0.0.276-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2edcd6948a21fa7fb4594094da37a1aa1d205b7abaa718bd27d48ba1d7977348"},
+    {file = "ruff-0.0.276-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57c49b525d8ca3838d8b614f42e342077bed95aedd9fe6e6ec419f39320c214e"},
+    {file = "ruff-0.0.276-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5980960a748ada3ddfe4ea7ff3a01b9113c456a14cb1a39b4c30783012d4cba6"},
+    {file = "ruff-0.0.276-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:12be4f007114cf5ed1242e522762651539521ec32ae0210cc4b8dfe434a872f0"},
+    {file = "ruff-0.0.276-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6ed8fc729b3e7b9f20a4e2aa6f24c798b06912f8a94cb3e8fd590eba055780df"},
+    {file = "ruff-0.0.276-py3-none-musllinux_1_2_i686.whl", hash = "sha256:735d724031212c2ab63fafdea49d4581ae866a1180d06c29b0b5481228ca6bb9"},
+    {file = "ruff-0.0.276-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:100ad9055d50977c2b4ab3de0db62d6e525bcd4aafbb660a842733bdbf650be9"},
+    {file = "ruff-0.0.276-py3-none-win32.whl", hash = "sha256:1b34a3673b2e5d97df8f7f04090c0b74e9ae6d3d172921d0e0781192954afddf"},
+    {file = "ruff-0.0.276-py3-none-win_amd64.whl", hash = "sha256:02deadc0f6abead6cc2d38ddd7100a52aba27a0d90315facaa44b8b4acdba162"},
+    {file = "ruff-0.0.276-py3-none-win_arm64.whl", hash = "sha256:a6bd5b53ac689a43c7afc45bd574a7b3efe0ceb192e26e95a055c770ef2045b9"},
+    {file = "ruff-0.0.276.tar.gz", hash = "sha256:d456c86eb6ce9225507f24fcc7bf72fa031bb7cc750023310e62889bf4ad4b6a"},
 ]
 
 [[package]]
@@ -845,14 +857,14 @@ telegram = ["requests"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.6.3"
+version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.6.3-py3-none-any.whl", hash = "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26"},
-    {file = "typing_extensions-4.6.3.tar.gz", hash = "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"},
+    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
+    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
 ]
 
 [[package]]
@@ -964,4 +976,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <=3.12"
-content-hash = "de5e232fac97271b2272a6315f0d8dc580671a65a431accfe0068eeeb54f4aca"
+content-hash = "b75df9d4751a3dc093fcc6477911d07d3b3e003fa930eb00db0c4320b91387b8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/jakecyr/openai-function-calling"
 [tool.poetry.dependencies]
 python = ">=3.10, <=3.12"
 typing-extensions = "^4.0"
+docstring-parser = "^0.15"
 
 [tool.poetry.group.dev]
 optional = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,8 +1,8 @@
 line-length = 88
 target-version = "py310"
-select = ["E", "F", "B", "Q", "I", "N", "D", "UP", "ANN", "S", "BLE", "FBT", "COM", "C4", "FA", "ICN", "G004", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SIM", "TID", "TCH", "ARG", "PTH", "TD", "ERA", "PL", "PLE", "PLR", "PLW", "RUF"]
+select = ["E", "F", "B", "Q", "I", "N", "D", "UP", "ANN", "S", "BLE", "FBT", "C4", "FA", "ICN", "G004", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SIM", "TID", "TCH", "ARG", "PTH", "TD", "ERA", "PL", "PLE", "PLR", "PLW", "RUF"]
 fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
-ignore = ["D407", "D406", "D203", "ANN101", "D213", "PLR0913"]
+ignore = ["D407", "D406", "D203", "ANN101", "D213", "PLR0913", "ANN401"]
 exclude = [
   ".bzr",
   ".direnv",
@@ -18,5 +18,5 @@ exclude = [
   ".venv",
 ]
 [per-file-ignores]
-"tests/*" = ["D103", "S101", "PLR2004", "ANN001", "D205", "E501"]
+"tests/*" = ["D103", "S101", "PLR2004", "ANN001", "D205", "E501", "D401"]
 "examples/*" = ["D103", "T201"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,5 +18,5 @@ exclude = [
   ".venv",
 ]
 [per-file-ignores]
-"tests/*" = ["D103", "S101"]
+"tests/*" = ["D103", "S101", "PLR2004", "ANN001", "D205", "E501"]
 "examples/*" = ["D103", "T201"]

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -175,8 +175,8 @@ def test_from_reference_returns_a_new_function() -> None:
         """Calculate the sum of integers and return the result.
 
         Args:
-            a (int): _description_
-            b (int): _description_
+            a (int): The first integer to sum.
+            b (int): The second integer to sum.
 
         Returns:
             int: _description_
@@ -197,6 +197,8 @@ def test_from_reference_returns_a_new_function() -> None:
     assert function_definition.parameters[1].name == "b"
     assert function_definition.parameters[0].type == "integer"
     assert function_definition.parameters[1].type == "integer"
+    assert function_definition.parameters[0].description == "The first integer to sum."
+    assert function_definition.parameters[1].description == "The second integer to sum."
 
 
 def test_from_reference_without_docstring_with_type_hints_return_expected_values() -> (

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -168,3 +168,178 @@ def test_to_dict_returns_same_value_as_to_json_schema() -> None:
         get_current_weather_function.to_json_schema()
         == get_current_weather_function.to_dict()
     )
+
+
+def test_from_reference_returns_a_new_function() -> None:
+    def sum(a: int, b: int) -> int:
+        """Calculate the sum of integers and return the result.
+
+        Args:
+            a (int): _description_
+            b (int): _description_
+
+        Returns:
+            int: _description_
+        """
+        return a + b
+
+    function_definition: Function = Function.from_function(sum)
+
+    assert isinstance(function_definition, Function)
+
+    assert function_definition.name == "sum"
+    assert (
+        function_definition.description
+        == "Calculate the sum of integers and return the result."
+    )
+    assert len(function_definition.parameters) == 2
+    assert function_definition.parameters[0].name == "a"
+    assert function_definition.parameters[1].name == "b"
+    assert function_definition.parameters[0].type == "integer"
+    assert function_definition.parameters[1].type == "integer"
+
+
+def test_from_reference_without_docstring_with_type_hints_return_expected_values() -> (
+    None
+):
+    def sum(a: int, b: int) -> int:
+        return a + b
+
+    function_definition: Function = Function.from_function(sum)
+
+    assert isinstance(function_definition, Function)
+
+    assert function_definition.name == "sum"
+    assert function_definition.description == ""
+    assert len(function_definition.parameters) == 2
+    assert function_definition.parameters[0].name == "a"
+    assert function_definition.parameters[1].name == "b"
+    assert function_definition.parameters[0].type == "integer"
+    assert function_definition.parameters[1].type == "integer"
+
+
+def test_from_reference_with_no_type_hints_or_docstrings_still_returns_parameters() -> (
+    None
+):
+    def sum(a, b) -> int:
+        return a + b
+
+    function_definition: Function = Function.from_function(sum)
+
+    assert isinstance(function_definition, Function)
+
+    assert function_definition.name == "sum"
+    assert function_definition.description == ""
+    assert len(function_definition.parameters) == 2
+    assert function_definition.parameters[0].name == "a"
+    assert function_definition.parameters[1].name == "b"
+
+
+def test_from_reference_with_only_type_hints_returns_expected_parameters() -> None:
+    def sum(a: int, b: int) -> int:
+        return a + b
+
+    function_definition: Function = Function.from_function(sum)
+
+    assert isinstance(function_definition, Function)
+
+    assert function_definition.name == "sum"
+    assert function_definition.description == ""
+    assert len(function_definition.parameters) == 2
+    assert function_definition.parameters[0].name == "a"
+    assert function_definition.parameters[0].type == "integer"
+    assert function_definition.parameters[1].name == "b"
+    assert function_definition.parameters[1].type == "integer"
+
+
+def test_from_reference_with_only_docstring_no_types_returns_parameters_with_null_types() -> (
+    None
+):
+    def sum(a, b) -> int:
+        """
+        Args:
+            a: The first integer value.
+            b: The second integer value.
+        """
+        return a + b
+
+    function_definition: Function = Function.from_function(sum)
+
+    assert isinstance(function_definition, Function)
+
+    assert function_definition.name == "sum"
+    assert len(function_definition.parameters) == 2
+    assert function_definition.parameters[0].name == "a"
+    assert function_definition.parameters[0].type == "null"
+    assert function_definition.parameters[0].description == "The first integer value."
+    assert function_definition.parameters[1].name == "b"
+    assert function_definition.parameters[1].type == "null"
+    assert function_definition.parameters[1].description == "The second integer value."
+
+
+def test_from_reference_with_only_docstring_with_types_returns_parameters_with_defined_types() -> (
+    None
+):
+    def sum(a, b) -> int:
+        """Sums two values.
+
+        Args:
+            a (integer): The first integer value.
+            b (integer): The second integer value.
+        """
+        return a + b
+
+    function_definition: Function = Function.from_function(sum)
+
+    assert isinstance(function_definition, Function)
+
+    assert function_definition.name == "sum"
+    assert function_definition.description == "Sums two values."
+    assert len(function_definition.parameters) == 2
+    assert function_definition.parameters[0].name == "a"
+    assert function_definition.parameters[0].type == "integer"
+    assert function_definition.parameters[0].description == "The first integer value."
+    assert function_definition.parameters[1].name == "b"
+    assert function_definition.parameters[1].type == "integer"
+    assert function_definition.parameters[1].description == "The second integer value."
+
+
+def test_from_reference_with_type_hints_and_docstring_without_types_returns_parameter_with_types_and_descriptions() -> (
+    None
+):
+    def sum(a: float, b: float) -> float:
+        """
+        Args:
+            a: The first float value.
+            b: The second float value.
+        """
+        return a + b
+
+    function_definition: Function = Function.from_function(sum)
+
+    assert isinstance(function_definition, Function)
+
+    assert function_definition.name == "sum"
+    assert function_definition.description == ""
+    assert len(function_definition.parameters) == 2
+    assert function_definition.parameters[0].name == "a"
+    assert function_definition.parameters[0].type == JsonSchemaType.NUMBER
+    assert function_definition.parameters[0].description == "The first float value."
+    assert function_definition.parameters[1].name == "b"
+    assert function_definition.parameters[1].type == JsonSchemaType.NUMBER
+    assert function_definition.parameters[1].description == "The second float value."
+
+
+def test_from_reference_with_no_parameters_throws_returns_empty_parameters_list() -> (
+    None
+):
+    def do_something() -> None:
+        pass
+
+    function_definition: Function = Function.from_function(do_something)
+
+    assert isinstance(function_definition, Function)
+
+    assert function_definition.name == "do_something"
+    assert function_definition.description == ""
+    assert len(function_definition.parameters) == 0

--- a/tests/test_function_inferer.py
+++ b/tests/test_function_inferer.py
@@ -1,0 +1,88 @@
+"""Test the function inferer class."""
+
+from openai_function_calling.function import Function
+from openai_function_calling.function_inferer import FunctionInferer
+
+
+def fully_documented_sum(a: int, b: int) -> int:
+    """Sum two values.
+
+    Args:
+        a: The first value to sum.
+        b: The second value to sum.
+
+    Returns:
+        The sum of the two values.
+    """
+    return a + b
+
+
+def no_docstring_sum(a: int, b: int) -> int:
+    return a + b
+
+
+def test_infer_from_function_reference_returns_a_function_instance() -> None:
+    function: Function = FunctionInferer.infer_from_function_reference(
+        fully_documented_sum
+    )
+
+    assert isinstance(function, Function)
+
+
+def test_infer_from_function_reference_returns_function_with_name_defined() -> None:
+    function: Function = FunctionInferer.infer_from_function_reference(
+        fully_documented_sum
+    )
+
+    assert function.name == fully_documented_sum.__name__
+
+
+def test_infer_from_function_reference_returns_function_with_description_defined() -> (
+    None
+):
+    function: Function = FunctionInferer.infer_from_function_reference(
+        fully_documented_sum
+    )
+
+    assert function.description == "Sum two values."
+
+
+def test_infer_from_function_reference_returns_function_with_expected_parameter_count() -> (
+    None
+):
+    function: Function = FunctionInferer.infer_from_function_reference(
+        fully_documented_sum
+    )
+
+    assert len(function.parameters) == 2
+
+
+def test_infer_from_function_reference_returns_function_with_expected_parameter_attributes() -> (
+    None
+):
+    function: Function = FunctionInferer.infer_from_function_reference(
+        fully_documented_sum
+    )
+
+    assert function.parameters[0].name == "a"
+    assert function.parameters[0].type == "integer"
+    assert function.parameters[0].description == "The first value to sum."
+    assert function.parameters[0].array_item_type is None
+    assert function.parameters[0].enum is None
+
+    assert function.parameters[1].name == "b"
+    assert function.parameters[1].type == "integer"
+    assert function.parameters[1].description == "The second value to sum."
+    assert function.parameters[1].array_item_type is None
+    assert function.parameters[1].enum is None
+
+
+def test_infer_from_function_reference_returns_function_with_expected_values() -> None:
+    function: Function = FunctionInferer.infer_from_function_reference(no_docstring_sum)
+
+    assert function.name == no_docstring_sum.__name__
+    assert len(function.parameters) == 2
+    assert function.parameters[0].name == "a"
+    assert function.parameters[0].type == "integer"
+    assert function.parameters[1].name == "b"
+    assert function.parameters[1].type == "integer"

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -1,0 +1,47 @@
+"""Helper function tests."""
+
+
+import pytest
+
+from openai_function_calling.helper_functions import python_type_to_json_schema_type
+from openai_function_calling.json_schema_type import JsonSchemaType
+
+
+def test_null():
+    assert python_type_to_json_schema_type(None) == JsonSchemaType.NULL.value
+
+
+@pytest.mark.parametrize("json_schema_type", list(JsonSchemaType))
+def test_json_schema_type_values(json_schema_type) -> None:
+    assert (
+        python_type_to_json_schema_type(json_schema_type.value)
+        == json_schema_type.value
+    )
+
+
+def test_int() -> None:
+    assert python_type_to_json_schema_type("int") == JsonSchemaType.INTEGER.value
+
+
+def test_float() -> None:
+    assert python_type_to_json_schema_type("float") == JsonSchemaType.NUMBER.value
+
+
+def test_complex() -> None:
+    assert python_type_to_json_schema_type("complex") == JsonSchemaType.NUMBER.value
+
+
+def test_str() -> None:
+    assert python_type_to_json_schema_type("str") == JsonSchemaType.STRING.value
+
+
+def test_bool() -> None:
+    assert python_type_to_json_schema_type("bool") == JsonSchemaType.BOOLEAN.value
+
+
+def test_dict() -> None:
+    assert python_type_to_json_schema_type("dict") == JsonSchemaType.OBJECT.value
+
+
+def test_list() -> None:
+    assert python_type_to_json_schema_type("list") == JsonSchemaType.ARRAY.value

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -7,7 +7,7 @@ from openai_function_calling.helper_functions import python_type_to_json_schema_
 from openai_function_calling.json_schema_type import JsonSchemaType
 
 
-def test_null():
+def test_null() -> None:
     assert python_type_to_json_schema_type(None) == JsonSchemaType.NULL.value
 
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -124,3 +124,81 @@ def test_to_json_schema_with_type_array_items_returns_expected_dict() -> None:
     ), "Expected parameter 'items' dict to have 'type' property."
     assert isinstance(parameter_dict["items"]["type"], str)
     assert parameter_dict["items"]["type"] == JsonSchemaType.STRING
+
+
+def test_eq_returns_true_if_parameters_are_equal() -> None:
+    parameter = Parameter(
+        name="unit",
+        type=JsonSchemaType.ARRAY,
+        array_item_type=JsonSchemaType.STRING,
+    )
+    other_parameter = Parameter(
+        name="unit",
+        type=JsonSchemaType.ARRAY,
+        array_item_type=JsonSchemaType.STRING,
+    )
+
+    assert parameter == other_parameter
+
+
+def test_eq_returns_false_if_parameters_are_not_equal() -> None:
+    parameter = Parameter(
+        name="unit",
+        type=JsonSchemaType.ARRAY,
+        array_item_type=JsonSchemaType.STRING,
+    )
+    other_parameter = Parameter(
+        name="other",
+        type=JsonSchemaType.ARRAY,
+        array_item_type=JsonSchemaType.STRING,
+    )
+
+    assert parameter != other_parameter
+
+
+def test_merge_replaces_values_if_they_are_not_defined() -> None:
+    parameter = Parameter(
+        name="unit",
+        type=JsonSchemaType.NULL,
+    )
+    other_parameter = Parameter(
+        name="other",
+        type=JsonSchemaType.ARRAY,
+        array_item_type=JsonSchemaType.STRING,
+        description="Some description",
+    )
+
+    parameter.merge(other_parameter)
+
+    assert parameter.type == JsonSchemaType.ARRAY
+    assert parameter.array_item_type == JsonSchemaType.STRING
+    assert parameter.description == "Some description"
+
+
+def test_merge_does_not_remove_values() -> None:
+    parameter = Parameter(
+        name="other",
+        type=JsonSchemaType.ARRAY,
+        array_item_type=JsonSchemaType.STRING,
+        description="Some description",
+    )
+    other_parameter = Parameter(
+        name="unit",
+        type=JsonSchemaType.NULL,
+    )
+
+    parameter.merge(other_parameter)
+
+    assert parameter.type == JsonSchemaType.ARRAY
+    assert parameter.array_item_type == JsonSchemaType.STRING
+    assert parameter.description == "Some description"
+
+
+def test_merge_with_invalid_type_raises_type_error() -> None:
+    parameter = Parameter(
+        name="unit",
+        type=JsonSchemaType.NULL,
+    )
+
+    with pytest.raises(TypeError):
+        parameter.merge(1)  # type: ignore


### PR DESCRIPTION
Use a function reference to get the function's annotations and docstring which can be used to get the function description and parameter names, types and descriptions.